### PR TITLE
Set IgnoreAppsRequireRestart to TRUE, to avoid restarting  critical apps

### DIFF
--- a/templates/unattended-upgrades.j2
+++ b/templates/unattended-upgrades.j2
@@ -73,6 +73,12 @@ Unattended-Upgrade::Automatic-Reboot "true";
 //  Default: "now"
 //Unattended-Upgrade::Automatic-Reboot-Time "02:00";
 
+// * unattended-upgrade:
+// - Do not upgrade apps if "XB-Upgrade-Requires: app-restart"
+// is set in the debian/control file.
+// This can be override with the option:
+Unattended-Upgrade::IgnoreAppsRequireRestart "true";
+
 // Use apt bandwidth limit feature, this example limits the download
 // speed to 70kb/sec
 //Acquire::http::Dl-Limit "70";

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,3 +1,3 @@
 ---
 __unattended_origins_patterns:
-  - 'origin=Debian,archive=${distro_codename},label=Debian-Security'
+  - 'origin=Debian,archive=stable,label=Debian-Security'


### PR DESCRIPTION
I am attempting to mimic these changes and apply them in this ansible role.
```
  * unattended-upgrade:
    - Do not upgrade apps if "XB-Upgrade-Requires: app-restart"
      is set in the debian/control file.
      This can be override with the option:
      Unattended-Upgrade::IgnoreAppsRequireRestart=true
```
https://github.com/mvo5/unattended-upgrades/blob/2f2683d6c2065e17379870ef4b366482f3a6c90e/debian/changelog#L806

So we could avoid restarting critical services as this suggests:
``` python
# check if the package is unsafe to upgrade unattended
            ignore_require_restart = apt_pkg.config.find_b(
                "Unattended-Upgrade::IgnoreAppsRequireRestart", False)
            upgrade_requires = pkg.candidate.record.get("Upgrade-Requires")
            if (pkg.marked_upgrade and ignore_require_restart is False and
                    upgrade_requires == "app-restart"):
                logging.debug("pkg '%s' requires app-restart, not safe to "
                              "upgrade unattended")
                return False
```
https://github.com/mvo5/unattended-upgrades/blob/89226202dc10c9aa11881df3ca57986a0d70e224/unattended-upgrade#L572-L579
