### PR TITLE
fix bug where archive was being set to codename

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you enable automatic reboot feature (`unattended_automatic_reboot`), the role
 ## Role Variables
 
 * `unattended_origins_patterns`: array of origins patterns to determine whether the package can be automatically installed, for more details see [Origins Patterns](#origins-patterns) below.
-    * Default for Debian: `['origin=Debian,archive=${distro_codename},label=Debian-Security']`
+    * Default for Debian: `['origin=Debian,codename=${distro_codename},label=Debian-Security']`
     * Default for Ubuntu: `['origin=Ubuntu,archive=${distro_codename}-security,label=Ubuntu']`
 * `unattended_package_blacklist`: packages which won't be automatically upgraded
     * Default: `[]`
@@ -88,7 +88,7 @@ By default, only security updates are allowed for both Ubuntu and Debian. You ca
 ```yaml
 # Archive based matching
 unattended_origins_patterns:
-  - 'origin=Debian,archive=${distro_codename},label=Debian-Security' # resolves to archive=jessie
+  - 'origin=Debian,codename=${distro_codename},label=Debian-Security' # resolves to codename=jessie
   - 'o=Debian,a=stable'
   - 'o=Debian,a=stable-updates'
   - 'o=Debian,a=proposed-updates'

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,3 +1,3 @@
 ---
 __unattended_origins_patterns:
-  - 'origin=Debian,archive=${distro_codename},label=Debian-Security'
+  - 'origin=Debian,codename=${distro_codename},label=Debian-Security'


### PR DESCRIPTION
At least on Debian Jessie, setting `archive` = `codename` is wrong and results security upgrades not being applied.

Not sure if this is a problem on Ubuntu as well.