### PR TITLE
Support for 'Unattended-Upgrade::Automatic-Reboot-Time'

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The role requires unattended-upgrades version 0.70 and newer, which is available
 
 ### Automatic Reboot
 
-If you enable automatic reboot feature (`unattended_automatic_reboot`), the role will install `update-notifier-common` package, which is required for detecting and executing reboot after the upgrade.
+If you enable automatic reboot feature (`unattended_automatic_reboot`), the role will install `update-notifier-common` package, which is required for detecting and executing reboot after the upgrade. You may optionally define a specific time for rebooting (`unattended_automatic_reboot_time`).
 
 **NOTE:** This feature is not currently supported on Debian Jessie, due to a missing replacement for the said package. Attempt to enable this feature on unsupported system will cause a failure. See [the discussion in #6](https://github.com/jnv/ansible-role-unattended-upgrades/issues/6) for more details.
 
@@ -43,6 +43,8 @@ If you enable automatic reboot feature (`unattended_automatic_reboot`), the role
     * Default: `false`
 * `unattended_automatic_reboot`: Automatically reboot system if any upgraded package requires it, immediately after the upgrade.
     * Default: `false`
+* `unattended_automatic_reboot_time`: Automatically reboot system if any upgraded package requires it, at the specific time (_HH:MM_) instead of immediately after the upgrade.
+    * Default: `false`
 
 
 ## Origins Patterns
@@ -60,7 +62,7 @@ Pattern is composed from specific keywords:
 
 You can review the available repositories using `apt-cache policy` and debug your choice using `unattended-upgrades -d` command on a target system.
 
-Additionaly unattended-upgrades support two macros (variables), derived from `/etc/debian_version`:
+Additionally unattended-upgrades support two macros (variables), derived from `/etc/debian_version`:
 
 * `${distro_id}` – Installed distribution name, e.g. `Debian` or `Ubuntu`.
 * `${distro_codename}` – Installed codename, e.g. `jessie` or `trusty`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,3 +53,8 @@ unattended_remove_unused_dependencies: false
 # Automatically reboot *WITHOUT CONFIRMATION* if a
 # the file /var/run/reboot-required is found after the upgrade
 unattended_automatic_reboot: false
+
+#Unattended-Upgrade::Automatic-Reboot-Time
+# If automatic reboot is enabled and needed, reboot at the specific
+# time instead of immediately
+unattended_automatic_reboot_time: false

--- a/templates/unattended-upgrades.j2
+++ b/templates/unattended-upgrades.j2
@@ -68,10 +68,12 @@ Unattended-Upgrade::Remove-Unused-Dependencies "true";
 Unattended-Upgrade::Automatic-Reboot "true";
 {% endif %}
 
+{% if unattended_automatic_reboot_time %}
 // If automatic reboot is enabled and needed, reboot at the specific
 // time instead of immediately
 //  Default: "now"
-//Unattended-Upgrade::Automatic-Reboot-Time "02:00";
+Unattended-Upgrade::Automatic-Reboot-Time "{{ unattended_automatic_reboot_time }}";
+{% endif %}
 
 // Use apt bandwidth limit feature, this example limits the download
 // speed to 70kb/sec


### PR DESCRIPTION
First of all, thank you for your clean and simple role, it simplified our configuration!

We needed to configure the automatic reboot time as well. So this PR introduces `unattended_automatic_reboot_time` variable for specifying the time in the `unattended-upgrades` configuration file.

Hope you like it, I'm looking forward to a merge! :smile: 