### PR TITLE
Add unattended_verbose (default 0) and unattended_random_sleep (default 1800)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ On some hosts you may find that the unattended-upgrade's cronfile `/etc/cron.dai
 * `unattended_verbose`: Define verbose level of APT
     * Default: `0` (no report)
     * Suggested: `1` (progress report)
+* `unattended_random_sleep`: Define when the apt job starts
+    * Default: `1800`
+    * Suggested: `0`
 
 ## Origins Patterns
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ On some hosts you may find that the unattended-upgrade's cronfile `/etc/cron.dai
     * Default: `false`
 * `unattended_automatic_reboot_time`: Automatically reboot system if any upgraded package requires it, at the specific time (_HH:MM_) instead of immediately after the upgrade.
     * Default: `false`
-
+* `unattended_verbose`: Define verbose level of APT
+    * Default: `0` (no report)
+    * Suggested: `1` (progress report)
 
 ## Origins Patterns
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,4 +59,18 @@ unattended_automatic_reboot: false
 # time instead of immediately
 unattended_automatic_reboot_time: false
 
+# APT::Periodic::Verbose "0";
+# - Send report mail to root
+#     0:  no report             (or null string)
+#     1:  progress report       (actually any string)
+#     2:  + command outputs     (remove -qq, remove 2>/dev/null, add -d)
+#     3:  + trace on
 unattended_verbose: 0
+
+# When the apt job starts, it will sleep for a random period between 0
+# and APT::Periodic::RandomSleep seconds
+# The default value is "1800" so that the script will stall for up to 30
+# minutes (1800 seconds) so that the mirror servers are not crushed by
+# everyone running their updates all at the same time
+unattended_random_sleep: 0
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -58,3 +58,5 @@ unattended_automatic_reboot: false
 # If automatic reboot is enabled and needed, reboot at the specific
 # time instead of immediately
 unattended_automatic_reboot_time: false
+
+unattended_verbose: 0

--- a/tasks/unattended-upgrades.yml
+++ b/tasks/unattended-upgrades.yml
@@ -10,8 +10,8 @@
   when: unattended_automatic_reboot
 
 - name: create APT auto-upgrades configuration
-  copy: >
-    src=auto-upgrades dest=/etc/apt/apt.conf.d/20auto-upgrades
+  template: >
+    src=auto-upgrades.j2 dest=/etc/apt/apt.conf.d/20auto-upgrades
     owner=root group=root mode=0644
 
 - name: create unattended-upgrades configuration

--- a/templates/auto-upgrades.j2
+++ b/templates/auto-upgrades.j2
@@ -2,3 +2,5 @@ APT::Periodic::Update-Package-Lists "1";
 APT::Periodic::Download-Upgradeable-Packages "1";
 APT::Periodic::AutocleanInterval "7";
 APT::Periodic::Unattended-Upgrade "1";
+APT::Periodic::Verbose "{{ unattended_verbose }}";
+APT::Periodic::RandomSleep "{{ unattended_random_sleep }}";

--- a/templates/unattended-upgrades.j2
+++ b/templates/unattended-upgrades.j2
@@ -75,14 +75,6 @@ Unattended-Upgrade::Automatic-Reboot "true";
 Unattended-Upgrade::Automatic-Reboot-Time "{{ unattended_automatic_reboot_time }}";
 {% endif %}
 
-// APT::Periodic::Verbose "0";
-// - Send report mail to root
-//     0:  no report             (or null string)
-//     1:  progress report       (actually any string)
-//     2:  + command outputs     (remove -qq, remove 2>/dev/null, add -d)
-//     3:  + trace on
-APT::Periodic::Verbose "{{ unattended_verbose }}";
-
 // Use apt bandwidth limit feature, this example limits the download
 // speed to 70kb/sec
 //Acquire::http::Dl-Limit "70";

--- a/templates/unattended-upgrades.j2
+++ b/templates/unattended-upgrades.j2
@@ -75,6 +75,14 @@ Unattended-Upgrade::Automatic-Reboot "true";
 Unattended-Upgrade::Automatic-Reboot-Time "{{ unattended_automatic_reboot_time }}";
 {% endif %}
 
+// APT::Periodic::Verbose "0";
+// - Send report mail to root
+//     0:  no report             (or null string)
+//     1:  progress report       (actually any string)
+//     2:  + command outputs     (remove -qq, remove 2>/dev/null, add -d)
+//     3:  + trace on
+APT::Periodic::Verbose "{{ unattended_verbose }}";
+
 // Use apt bandwidth limit feature, this example limits the download
 // speed to 70kb/sec
 //Acquire::http::Dl-Limit "70";


### PR DESCRIPTION
Define verbose level APT::Periodic::Verbose

  0:  no report             (or null string)
  1:  progress report       (actually any string)
  2:  + command outputs     (remove -qq, remove 2>/dev/null, add -d)
  3:  + trace on
