### PR TITLE
Get rid of backup file

### DIFF
--- a/tasks/unattended-upgrades.yml
+++ b/tasks/unattended-upgrades.yml
@@ -22,3 +22,9 @@
   template: >
     src=unattended-upgrades.j2 dest=/etc/apt/apt.conf.d/50unattended-upgrades
     owner=root group=root mode=0644
+
+- name: get rid of backup file
+  file: >
+    path=/etc/apt/apt.conf.d/50unattended-upgrades.ucf-dist
+    state=absent
+


### PR DESCRIPTION
This file is created by apt-get install because of the modifications in the original file
When using apt a warning is issued that a file in /etc/apt/apt.conf.d is found with an unknown extension