### PR TITLE
Include APT::Periodic options

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ On some hosts you may find that the unattended-upgrade's cronfile `/etc/cron.dai
     * Default: `false`
 * `unattended_ignore_apps_require_restart`: unattended-upgrades won't automatically upgrade some critical packages requiring restart after an upgrade (i.e. there is `XB-Upgrade-Requires: app-restart` directive in their debian/control file). With this option set to `true`, unattended-upgrades will upgrade these packages regardless of the directive.
     * Default: `false`
+* `unattended_verbose`: Define verbose level of APT
+    * Default: `0` (no report)
+    * Suggested: `1` (progress report)
 
 ## Origins Patterns
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ On some hosts you may find that the unattended-upgrade's cronfile `/etc/cron.dai
 * `unattended_verbose`: Define verbose level of APT
     * Default: `0` (no report)
     * Suggested: `1` (progress report)
+* `unattended_random_sleep`: Define when the apt job starts
+    * Default: `1800`
+    * Suggested: `0`
 
 ## Origins Patterns
 

--- a/README.md
+++ b/README.md
@@ -51,12 +51,23 @@ On some hosts you may find that the unattended-upgrade's cronfile `/etc/cron.dai
     * Default: `false`
 * `unattended_ignore_apps_require_restart`: unattended-upgrades won't automatically upgrade some critical packages requiring restart after an upgrade (i.e. there is `XB-Upgrade-Requires: app-restart` directive in their debian/control file). With this option set to `true`, unattended-upgrades will upgrade these packages regardless of the directive.
     * Default: `false`
-* `unattended_verbose`: Define verbose level of APT
+* `unattended_verbose`: Define verbosity level of APT for periodic runs. The output will be sent to root.
+    * Possible options:
+      * `0`: no report
+      * `1`: progress report
+      * `2`: + command outputs
+      * `3`: + trace on
     * Default: `0` (no report)
-    * Suggested: `1` (progress report)
-* `unattended_random_sleep`: Define when the apt job starts
-    * Default: `1800`
-    * Suggested: `0`
+* `unattended_update_package_list`: Do "apt-get update" automatically every n-days (0=disable)
+    * Default: `1`
+* `unattended_download_upgradeable`: Do "apt-get upgrade --download-only" every n-days (0=disable)
+    * Default: `0`
+* `unattended_autoclean_interval`: Do "apt-get autoclean" every n-days (0=disable)
+    * Default: `7`
+* `unattended_clean_interval`: Do "apt-get clean" every n-days (0=disable)
+    * Default: `0`
+* `unattended_random_sleep`: Define maximum for a random interval in seconds after which the apt job starts (only for systems without systemd)
+    * Default: `1800` (30 minutes)
 
 ## Origins Patterns
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -63,3 +63,5 @@ unattended_automatic_reboot_time: false
 # Do upgrade application even if it requires restart after upgrade
 # I.e. "XB-Upgrade-Requires: app-restart" is set in the debian/control file
 unattended_ignore_apps_require_restart: false
+
+unattended_verbose: 0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -64,18 +64,40 @@ unattended_automatic_reboot_time: false
 # I.e. "XB-Upgrade-Requires: app-restart" is set in the debian/control file
 unattended_ignore_apps_require_restart: false
 
-# APT::Periodic::Verbose "0";
+### APT::Periodic configuration
+# Snatched from /usr/lib/apt/apt.systemd.daily
+
+#APT::Periodic::Update-Package-Lists "0";
+# - Do "apt-get update" automatically every n-days (0=disable)
+unattended_update_package_list: 1
+
+#APT::Periodic::Download-Upgradeable-Packages "0";
+# - Do "apt-get upgrade --download-only" every n-days (0=disable)
+#unattended_download_upgradeable: 0
+
+#APT::Periodic::AutocleanInterval "0";
+# - Do "apt-get autoclean" every n-days (0=disable)
+unattended_autoclean_interval: 7
+
+#APT::Periodic::CleanInterval "0";
+# - Do "apt-get clean" every n-days (0=disable)
+#unattended_clean_interval: 0
+
+#APT::Periodic::Verbose "0";
 # - Send report mail to root
 #     0:  no report             (or null string)
 #     1:  progress report       (actually any string)
 #     2:  + command outputs     (remove -qq, remove 2>/dev/null, add -d)
 #     3:  + trace on
-unattended_verbose: 0
+#unattended_verbose: 0
 
+## Cron systems only
+
+#APT::Periodic::RandomSleep
 # When the apt job starts, it will sleep for a random period between 0
 # and APT::Periodic::RandomSleep seconds
 # The default value is "1800" so that the script will stall for up to 30
 # minutes (1800 seconds) so that the mirror servers are not crushed by
 # everyone running their updates all at the same time
-unattended_random_sleep: 0
-
+# Kept undefined to allow default (1800)
+#unattended_random_sleep: 0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -64,4 +64,18 @@ unattended_automatic_reboot_time: false
 # I.e. "XB-Upgrade-Requires: app-restart" is set in the debian/control file
 unattended_ignore_apps_require_restart: false
 
+# APT::Periodic::Verbose "0";
+# - Send report mail to root
+#     0:  no report             (or null string)
+#     1:  progress report       (actually any string)
+#     2:  + command outputs     (remove -qq, remove 2>/dev/null, add -d)
+#     3:  + trace on
 unattended_verbose: 0
+
+# When the apt job starts, it will sleep for a random period between 0
+# and APT::Periodic::RandomSleep seconds
+# The default value is "1800" so that the script will stall for up to 30
+# minutes (1800 seconds) so that the mirror servers are not crushed by
+# everyone running their updates all at the same time
+unattended_random_sleep: 0
+

--- a/tasks/unattended-upgrades.yml
+++ b/tasks/unattended-upgrades.yml
@@ -14,8 +14,8 @@
   when: unattended_automatic_reboot
 
 - name: create APT auto-upgrades configuration
-  copy: >
-    src=auto-upgrades dest=/etc/apt/apt.conf.d/20auto-upgrades
+  template: >
+    src=auto-upgrades.j2 dest=/etc/apt/apt.conf.d/20auto-upgrades
     owner=root group=root mode=0644
 
 - name: create unattended-upgrades configuration

--- a/templates/auto-upgrades.j2
+++ b/templates/auto-upgrades.j2
@@ -1,6 +1,26 @@
-APT::Periodic::Update-Package-Lists "1";
-APT::Periodic::Download-Upgradeable-Packages "1";
-APT::Periodic::AutocleanInterval "7";
 APT::Periodic::Unattended-Upgrade "1";
-APT::Periodic::Verbose "{{ unattended_verbose }}";
-APT::Periodic::RandomSleep "{{ unattended_random_sleep }}";
+APT::Periodic::Update-Package-Lists "{{unattended_update_package_list}}";
+
+{% if unattended_update_package_list is defined %}
+APT::Periodic::Update-Package-Lists "{{unattended_update_package_list}}";
+{% endif %}
+
+{% if unattended_download_upgradeable is defined %}
+APT::Periodic::Download-Upgradeable-Packages "{{unattended_download_upgradeable}}";
+{% endif %}
+
+{% if unattended_autoclean_interval is defined %}
+APT::Periodic::AutocleanInterval "{{unattended_autoclean_interval}}";
+{% endif %}
+
+{% if unattended_clean_interval is defined %}
+APT::Periodic::CleanInterval "{{unattended_clean_interval}}";
+{% endif %}
+
+{% if unattended_verbose is defined %}
+APT::Periodic::Verbose "{{unattended_verbose}}";
+{% endif %}
+
+{% if unattended_random_sleep is defined %}
+APT::Periodic::RandomSleep "{{unattended_random_sleep}}";
+{% endif %}

--- a/templates/auto-upgrades.j2
+++ b/templates/auto-upgrades.j2
@@ -2,3 +2,5 @@ APT::Periodic::Update-Package-Lists "1";
 APT::Periodic::Download-Upgradeable-Packages "1";
 APT::Periodic::AutocleanInterval "7";
 APT::Periodic::Unattended-Upgrade "1";
+APT::Periodic::Verbose "{{ unattended_verbose }}";
+APT::Periodic::RandomSleep "{{ unattended_random_sleep }}";

--- a/templates/unattended-upgrades.j2
+++ b/templates/unattended-upgrades.j2
@@ -81,6 +81,14 @@ Unattended-Upgrade::Automatic-Reboot-Time "{{ unattended_automatic_reboot_time }
 Unattended-Upgrade::IgnoreAppsRequireRestart "true";
 {% endif %}
 
+// APT::Periodic::Verbose "0";
+// - Send report mail to root
+//     0:  no report             (or null string)
+//     1:  progress report       (actually any string)
+//     2:  + command outputs     (remove -qq, remove 2>/dev/null, add -d)
+//     3:  + trace on
+APT::Periodic::Verbose "{{ unattended_verbose }}";
+
 // Use apt bandwidth limit feature, this example limits the download
 // speed to 70kb/sec
 //Acquire::http::Dl-Limit "70";

--- a/templates/unattended-upgrades.j2
+++ b/templates/unattended-upgrades.j2
@@ -81,14 +81,6 @@ Unattended-Upgrade::Automatic-Reboot-Time "{{ unattended_automatic_reboot_time }
 Unattended-Upgrade::IgnoreAppsRequireRestart "true";
 {% endif %}
 
-// APT::Periodic::Verbose "0";
-// - Send report mail to root
-//     0:  no report             (or null string)
-//     1:  progress report       (actually any string)
-//     2:  + command outputs     (remove -qq, remove 2>/dev/null, add -d)
-//     3:  + trace on
-APT::Periodic::Verbose "{{ unattended_verbose }}";
-
 // Use apt bandwidth limit feature, this example limits the download
 // speed to 70kb/sec
 //Acquire::http::Dl-Limit "70";


### PR DESCRIPTION
Replaces #25.

These options should go to a single configuration template, per #32.