### PR TITLE
Update apt cache before installing packages

### DIFF
--- a/tasks/reboot.yml
+++ b/tasks/reboot.yml
@@ -2,6 +2,8 @@
 # Ignored, since newer distros don't need this package
 # https://github.com/jnv/ansible-role-unattended-upgrades/issues/6
 - name: install update-notifier-common
-  apt: pkg=update-notifier-common state=present
+  apt:
+    pkg: update-notifier-common
+    state: present
   ignore_errors: true
 

--- a/tasks/reboot.yml
+++ b/tasks/reboot.yml
@@ -5,6 +5,7 @@
   apt:
     pkg: update-notifier-common
     state: present
+    update_cache: yes
     cache_valid_time: 3600
   ignore_errors: true
 

--- a/tasks/reboot.yml
+++ b/tasks/reboot.yml
@@ -5,5 +5,6 @@
   apt:
     pkg: update-notifier-common
     state: present
+    cache_valid_time: 3600
   ignore_errors: true
 

--- a/tasks/unattended-upgrades.yml
+++ b/tasks/unattended-upgrades.yml
@@ -7,18 +7,26 @@
   when: (ansible_distribution == "Debian") and (ansible_distribution_release == "wheezy")
 
 - name: install unattended-upgrades
-  apt: pkg=unattended-upgrades state=present
+  apt:
+    pkg: unattended-upgrades
+    state: present
 
 - name: install reboot dependencies
   include: reboot.yml
   when: unattended_automatic_reboot
 
 - name: create APT auto-upgrades configuration
-  copy: >
-    src=auto-upgrades dest=/etc/apt/apt.conf.d/20auto-upgrades
-    owner=root group=root mode=0644
+  copy:
+    src: auto-upgrades
+    dest: /etc/apt/apt.conf.d/20auto-upgrades
+    owner: root
+    group: root
+    mode: 0644
 
 - name: create unattended-upgrades configuration
-  template: >
-    src=unattended-upgrades.j2 dest=/etc/apt/apt.conf.d/50unattended-upgrades
-    owner=root group=root mode=0644
+  template:
+    src: unattended-upgrades.j2
+    dest: /etc/apt/apt.conf.d/50unattended-upgrades
+    owner: root
+    group: root
+    mode: 0644

--- a/tasks/unattended-upgrades.yml
+++ b/tasks/unattended-upgrades.yml
@@ -10,6 +10,7 @@
   apt:
     pkg: unattended-upgrades
     state: present
+    update_cache: yes
     cache_valid_time: 3600
 
 - name: install reboot dependencies

--- a/tasks/unattended-upgrades.yml
+++ b/tasks/unattended-upgrades.yml
@@ -10,6 +10,7 @@
   apt:
     pkg: unattended-upgrades
     state: present
+    cache_valid_time: 3600
 
 - name: install reboot dependencies
   include: reboot.yml


### PR DESCRIPTION
When using the role on a machine which APT cache have not been updated in some time, it might fail installing the packages.

I just add the `cache_valid_time` option when using Ansible's APT module.