### PR TITLE
tasks/main.yml: Only run on Debian-based distributions.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,3 @@
  - include: unattended-upgrades.yml
    tags: unattended
+   when: ansible_distribution == "Debian" or ansible_distribution == "Ubuntu"


### PR DESCRIPTION
I run a mixed CentOS/Debian environment where all hosts are in a 'all' hosts playbook which skips tasks based on `ansible_distribution` logic.

This tiny branch adds this logic to the unattended-upgrades role.