### PR TITLE
Update syntax for Ansible 2.4

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Jan Vlnas
   description: Setup unattended-upgrades on Debian-based systems
   license: GPLv2
-  min_ansible_version: 1.4
+  min_ansible_version: 2.4
   platforms:
   - name: Ubuntu
     versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,3 @@
- - include: unattended-upgrades.yml
+---
+ - import_tasks: unattended-upgrades.yml
    tags: unattended

--- a/tasks/unattended-upgrades.yml
+++ b/tasks/unattended-upgrades.yml
@@ -12,7 +12,7 @@
     state: present
 
 - name: install reboot dependencies
-  include: reboot.yml
+  include_tasks: reboot.yml
   when: unattended_automatic_reboot
 
 - name: create APT auto-upgrades configuration


### PR DESCRIPTION
Since Ansible 2.4, the syntax for role and tasks include has been modified [0].

The old **include** syntax still works, but it throws a **deprecated** warning.

This commit update the syntax to be compatible with Ansible 2.4. But it's not backwards compatible.

[0] https://docs.ansible.com/ansible/latest/playbooks_reuse.html