### PR TITLE
Adds support for Dpkg::Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ On some hosts you may find that the unattended-upgrade's cronfile `/etc/cron.dai
     * Default: `0`
 * `unattended_random_sleep`: Define maximum for a random interval in seconds after which the apt job starts (only for systems without systemd)
     * Default: `1800` (30 minutes)
+* `unattended_dpkg_options`: Provide dpkg flags during unattended-upgrades runs, e.g. "--force-confdef", "--force-confold"
+    * Default: `[]`
 
 ## Origins Patterns
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -101,3 +101,15 @@ unattended_autoclean_interval: 7
 # everyone running their updates all at the same time
 # Kept undefined to allow default (1800)
 #unattended_random_sleep: 0
+
+#Dpkg::Options
+# Provide dpkg options that take effect during unattended upgrades.
+# By default no flags are appended. Configuration file changes can
+# block installation of certain packages. Passing the flags
+# "--force-confdef" and "--force-confold" will ensure updates are applied
+# and old configuration files are preserved.
+unattended_dpkg_options: []
+
+# unattended_dpkg_options:
+#   - "--force-confdef"
+#   - "--force-confold"

--- a/templates/unattended-upgrades.j2
+++ b/templates/unattended-upgrades.j2
@@ -81,6 +81,15 @@ Unattended-Upgrade::Automatic-Reboot-Time "{{ unattended_automatic_reboot_time }
 Unattended-Upgrade::IgnoreAppsRequireRestart "true";
 {% endif %}
 
+{% if unattended_dpkg_options %}
+// Append options for governing dpkg behavior, e.g. --force-confdef.
+Dpkg::Options {
+{% for dpkg_option in unattended_dpkg_options %}
+    "{{ dpkg_option }}";
+{% endfor %}
+};
+{% endif %}
+
 // Use apt bandwidth limit feature, this example limits the download
 // speed to 70kb/sec
 //Acquire::http::Dl-Limit "70";


### PR DESCRIPTION
Creates new default role var `unattended_dpkg_options`, set to an empty
list. The default behavior of the role does not change.

For those interested, additional options can be applied to dpkg during
unattended upgrades runs by declaring them as a list, e.g.

```
unattended_dpkg_options:
  - "--force-confdef"
  - "--force-confold"
```

The above flags are necessary to ensure unattended-upgrades complete
even when conf file changes were detected (which prompts during
interactive upgrades).