### PR TITLE
Make role ansible 2.4 compatible

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,2 @@
- - include: unattended-upgrades.yml
+ - import_tasks: unattended-upgrades.yml
    tags: unattended


### PR DESCRIPTION
Fixes
[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated. Use 'import_tasks' for static inclusions or 'include_tasks'
 for dynamic inclusions. This feature will be removed in a future release.