### PR TITLE
Make role ansible 2.4 compatible

### DIFF
--- a/tasks/unattended-upgrades.yml
+++ b/tasks/unattended-upgrades.yml
@@ -12,7 +12,7 @@
     state: present
 
 - name: install reboot dependencies
-  include: reboot.yml
+  import_tasks: reboot.yml
   when: unattended_automatic_reboot
 
 - name: create APT auto-upgrades configuration


### PR DESCRIPTION
Fixes
[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated. Use 'import_tasks' for static inclusions or 'include_tasks'
 for dynamic inclusions. This feature will be removed in a future release.