### PR TITLE
Skip update-notifier-common step on Debian 8 or newer

### DIFF
--- a/tasks/reboot.yml
+++ b/tasks/reboot.yml
@@ -6,4 +6,7 @@
     pkg: update-notifier-common
     state: present
   ignore_errors: true
-
+  when: |
+          not ( ansible_distribution | lower == 'debian'
+                and ( ansible_distribution_major_version == '8'
+                or    ansible_distribution_major_version == '9'))

--- a/tasks/reboot.yml
+++ b/tasks/reboot.yml
@@ -5,7 +5,6 @@
   apt:
     pkg: update-notifier-common
     state: present
-  when: not ( ansible_distribution | lower == 'debian'
-            and (  ansible_distribution_major_version == '8'
-                or ansible_distribution_major_version == '9' ))
+  when: not (     ansible_distribution | lower       == 'debian'
+              and ansible_distribution_major_version >= '8' )
   ignore_errors: true

--- a/tasks/reboot.yml
+++ b/tasks/reboot.yml
@@ -5,8 +5,7 @@
   apt:
     pkg: update-notifier-common
     state: present
+  when: not ( ansible_distribution | lower == 'debian'
+            and (  ansible_distribution_major_version == '8'
+                or ansible_distribution_major_version == '9' ))
   ignore_errors: true
-  when: |
-          not ( ansible_distribution | lower == 'debian'
-                and ( ansible_distribution_major_version == '8'
-                or    ansible_distribution_major_version == '9'))


### PR DESCRIPTION
to avoid unnecessary scary red warning messages appearing on Jessie or newer. See discussion [here](https://github.com/jnv/ansible-role-unattended-upgrades/issues/6#issuecomment-361236301).

Fixes #44.