### PR TITLE
Added no-op flag to support the (broken) Ansible dependency mechanism

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -120,3 +120,7 @@ unattended_dpkg_options: []
 
 # Use apt bandwidth limit feature, this example limits the download speed to 70kb/sec
 #unattended_dl_limit: 70
+
+# Set to false to turn the role into a no-op. Useful when using
+# the Ansible role dependency mechanism.
+unattended_enabled: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,3 @@
  - include: unattended-upgrades.yml
    tags: unattended
+   when: unattended_enabled

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,3 @@
- - include: unattended-upgrades.yml
+ - include_tasks: unattended-upgrades.yml
    tags: unattended
    when: unattended_enabled


### PR DESCRIPTION
The Ansible role dependency feature is slightly broken. When a dependency is declared, the dependency is run before the dependent role. This is analogous to importing a function in a programming language, and having that function executed at the point of import. By adding the flag in this pull request, the dependency can be told to not run. Then, at the appropriate point in the code, `include_role` or `import_role` can be used to run the dependency. This decouples the formation of a role dependency graph from the execution of the roles themselves and gives many benefits.