### PR TITLE
Support "Unattended-Upgrade::Update-Days"

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ On some hosts you may find that the unattended-upgrade's cronfile `/etc/cron.dai
     * Default: `false`
 * `unattended_automatic_reboot_time`: Automatically reboot system if any upgraded package requires it, at the specific time (_HH:MM_) instead of immediately after the upgrade.
     * Default: `false`
+* `unattended_update_days`: Set the days of the week that updates should be applied. The days can be specified as localized abbreviated or full names. Or as integers where "0" is Sunday, "1" is Monday etc. Example: `{"Mon";"Fri"};`
+    * Default: disabled
 * `unattended_ignore_apps_require_restart`: unattended-upgrades won't automatically upgrade some critical packages requiring restart after an upgrade (i.e. there is `XB-Upgrade-Requires: app-restart` directive in their debian/control file). With this option set to `true`, unattended-upgrades will upgrade these packages regardless of the directive.
     * Default: `false`
 * `unattended_verbose`: Define verbosity level of APT for periodic runs. The output will be sent to root.

--- a/templates/unattended-upgrades.j2
+++ b/templates/unattended-upgrades.j2
@@ -75,6 +75,15 @@ Unattended-Upgrade::Automatic-Reboot "true";
 Unattended-Upgrade::Automatic-Reboot-Time "{{ unattended_automatic_reboot_time }}";
 {% endif %}
 
+{% if unattended_update_days is defined %}
+// Set the days of the week that updates should be applied. The days can be specified
+// as localized abbreviated or full names. Or as integers where "0" is Sunday, "1" is
+// Monday etc.
+// Example - apply updates only on Monday and Friday:
+// {"Mon";"Fri"};
+Unattended-Upgrade::Update-Days {{ unattended_update_days }};
+{% endif %}
+
 {% if unattended_ignore_apps_require_restart %}
 // Do upgrade application even if it requires restart after upgrade
 // I.e. "XB-Upgrade-Requires: app-restart" is set in the debian/control file

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -52,6 +52,9 @@
     - name: Get apt-config variables
       shell: apt-config dump
       register: aptconfig
+
+    - debug: var=aptconfig.stdout
+
     - name: Check for registered variables
       assert:
         that: item in aptconfig.stdout

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -61,7 +61,10 @@
         - 'Unattended-Upgrade::MinimalSteps "true"'
         - 'Unattended-Upgrade::InstallOnShutdown "true"'
         - 'Unattended-Upgrade::Automatic-Reboot "true"'
-        - 'Unattended-Upgrade::Update-Days {"Sat"}'
+        # NOTE: this uses the array syntax, which requires one
+        # top-level record, then one item per line
+        - 'Unattended-Upgrade::Update-Days "";'
+        - 'Unattended-Upgrade::Update-Days:: "Sat";'
 
     - name: Dry run unattended-upgrades
       command: /usr/bin/unattended-upgrades --dry-run

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -36,7 +36,7 @@
     unattended_minimal_steps: true
     unattended_install_on_shutdown: true
     unattended_automatic_reboot: true
-    unattended_update_days: '{"Mon"}'
+    unattended_update_days: '{"Sat"}'
   roles:
     # Searched for in ../.. (see ansible.cfg)
     - ansible-role-unattended-upgrades

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -36,6 +36,7 @@
     unattended_minimal_steps: true
     unattended_install_on_shutdown: true
     unattended_automatic_reboot: true
+    unattended_update_days: '{"Mon"}'
   roles:
     # Searched for in ../.. (see ansible.cfg)
     - ansible-role-unattended-upgrades

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -52,9 +52,6 @@
     - name: Get apt-config variables
       shell: apt-config dump
       register: aptconfig
-
-    - debug: var=aptconfig.stdout
-
     - name: Check for registered variables
       assert:
         that: item in aptconfig.stdout

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -60,6 +60,7 @@
         - 'Unattended-Upgrade::MinimalSteps "true"'
         - 'Unattended-Upgrade::InstallOnShutdown "true"'
         - 'Unattended-Upgrade::Automatic-Reboot "true"'
+        - 'Unattended-Upgrade::Update-Days {"Sat"}'
 
     - name: Dry run unattended-upgrades
       command: /usr/bin/unattended-upgrades --dry-run


### PR DESCRIPTION
I had the need to ensure installation (& presumably, reboot) will only occur on a Saturday night, because Sunday is a "day off" for a specific client, which buys them some time to react in case of trouble at reboot (like happened recently on production instances).

I've followed the documentation at https://github.com/mvo5/unattended-upgrades.

Thanks for considering integrating this!