### PR TITLE
Add support for setting apt-listchanges "which" items

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,12 +40,19 @@ unattended_install_on_shutdown: false
 # If empty or unset then no email is sent, make sure that you
 # have a working mail setup on your system. A package that provides
 # 'mailx' must be installed.
+# This items is also used to configure apt-listchanges
 unattended_mail: false
 
 #Unattended-Upgrade::MailOnlyOnError
 # Set this value to "true" to get emails only on errors. Default
 # is to always send a mail if Unattended-Upgrade::Mail is set
 unattended_mail_only_on_error: false
+
+unattended_mail_listchanges_which: news
+# This configures the "which" option of apt-listchanges.
+# By default only news is sent.
+# Possible options are news, changelogs, or both.
+# Also see 'man apt-listchanges'.
 
 #Unattended-Upgrade::Remove-Unused-Dependencies
 # Do automatic removal of new unused dependencies after the upgrade

--- a/tasks/unattended-upgrades.yml
+++ b/tasks/unattended-upgrades.yml
@@ -46,5 +46,4 @@
     - opt: which
       val: "{{ unattended_mail_listchanges_which }}"
   when:
-    - unattended_mail is defined
-    - unattended_mail_listchanges is defined
+    - unattended_mail != False

--- a/tasks/unattended-upgrades.yml
+++ b/tasks/unattended-upgrades.yml
@@ -32,3 +32,19 @@
     owner: root
     group: root
     mode: 0644
+    
+- name: Ensure apt-listchanges emails the configured items
+  ini_file:
+    path: /etc/apt/listchanges.conf
+    section: apt
+    no_extra_spaces: true
+    option: "{{ item.opt }}"
+    value: "{{ item.val }}"
+  with_items:
+    - opt: email_address
+      val: "{{ unattended_mail }}"
+    - opt: which
+      val: "{{ unattended_mail_listchanges_which }}"
+  when:
+    - unattended_mail is defined
+    - unattended_mail_listchanges is defined


### PR DESCRIPTION
Does not change current behavior, but allows setting ` unattended_mail_listchanges_which` to either `both` or `changelogs`.
This is helpful for instance with Debian 9, to be notified about the changelog of security updates have automatically been installed.