### PR TITLE
Use minimal steps by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ On some hosts you may find that the unattended-upgrade's cronfile `/etc/cron.dai
 * `unattended_autofix_interrupted_dpkg`: whether on unclean dpkg exit to run `dpkg --force-confold --configure -a`
     * Default: `true`
 * `unattended_minimal_steps`: split the upgrade into the smallest possible chunks so that they can be interrupted with SIGUSR1.
-    * Default: `false`
+    * Default: `true`
 * `unattended_install_on_shutdown`: install all unattended-upgrades when the machine is shuting down.
     * Default: `false`
 * `unattended_mail`: e-mail address to send information about upgrades or problems with unattended upgrades

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,7 +27,7 @@ unattended_autofix_interrupted_dpkg: true
 # they can be interrupted with SIGUSR1. This makes the upgrade
 # a bit slower but it has the benefit that shutdown while a upgrade
 # is running is possible (with a small delay)
-unattended_minimal_steps: false
+unattended_minimal_steps: true
 
 #Unattended-Upgrade::InstallOnShutdown
 # Install all unattended-upgrades when the machine is shuting down

--- a/templates/unattended-upgrades.j2
+++ b/templates/unattended-upgrades.j2
@@ -27,13 +27,11 @@ Unattended-Upgrade::Package-Blacklist {
 Unattended-Upgrade::AutoFixInterruptedDpkg "false";
 {% endif %}
 
-{% if unattended_minimal_steps %}
 // Split the upgrade into the smallest possible chunks so that
 // they can be interrupted with SIGUSR1. This makes the upgrade
 // a bit slower but it has the benefit that shutdown while a upgrade
 // is running is possible (with a small delay)
-Unattended-Upgrade::MinimalSteps "true";
-{% endif %}
+Unattended-Upgrade::MinimalSteps "{{ unattended_minimal_steps | lower }}";
 
 {% if unattended_install_on_shutdown %}
 // Install all unattended-upgrades when the machine is shuting down


### PR DESCRIPTION
This is a saner default and unattended-upgrades made the switch as of version 0.95 in August 2017: https://github.com/mvo5/unattended-upgrades/commit/16fb837e0485e49fba537a7c11ee144ef9d1a4cc

Unfortunately, that switch means the role is currently unable to set this to false because when configured to false the setting is omitted.

This PR does two things:
1. Updates the default to match current behavior; and
2. Fixes the ability to specify the behavior either way.

I'm happy to split those changes up if they're not both welcome.