### PR TITLE
Add the ansible_managed string at beginning of the deployed files

### DIFF
--- a/templates/auto-upgrades.j2
+++ b/templates/auto-upgrades.j2
@@ -1,3 +1,5 @@
+// {{ ansible_managed }}
+
 APT::Periodic::Unattended-Upgrade "1";
 
 {% if unattended_update_package_list is defined %}

--- a/templates/unattended-upgrades.j2
+++ b/templates/unattended-upgrades.j2
@@ -1,3 +1,5 @@
+// {{ ansible_managed }}
+
 // Unattended-Upgrade::Origins-Pattern controls which packages are
 // upgraded.
 Unattended-Upgrade::Origins-Pattern {


### PR DESCRIPTION
The ansible_managed string is only added if unattended_ansible_header is
true, which is currently default.

Closes: jnv/ansible-role-unattended-upgrades#69