### PR TITLE
fix: unattended-upgrades stops when powermgmt-base is missing

### DIFF
--- a/tasks/unattended-upgrades.yml
+++ b/tasks/unattended-upgrades.yml
@@ -13,6 +13,11 @@
     cache_valid_time: "{{ unattended_cache_valid_time }}"
     update_cache: yes
 
+- name: Ensure powermgmt-base is installed
+  apt:
+    name: powermgmt-base
+    state: present
+
 - name: install reboot dependencies
   include: reboot.yml
   when: unattended_automatic_reboot|bool


### PR DESCRIPTION
On some systems unattended-upgrades fails or silently fails with this message:
```
Unattended upgrade result: Upgrade was interrupted
Unattended-upgrades log:
Checking if system is running on battery is skipped. Please install
powermgmt-base package to check power status and skip installing updates
when the system is running on battery.
```

Installing it as a prerequisite solves the issue.