### PR TITLE
Make unattended-upgrade's period configurable.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -85,6 +85,11 @@ unattended_syslog_enable: false
 ### APT::Periodic configuration
 # Snatched from /usr/lib/apt/apt.systemd.daily
 
+# APT::Periodic::Unattended-Upgrade "1";
+# - Run the "unattended-upgrade" security upgrade script
+#   every n-days (0=disabled)
+unattended_interval: 1
+
 #APT::Periodic::Update-Package-Lists "0";
 # - Do "apt-get update" automatically every n-days (0=disable)
 unattended_update_package_list: 1

--- a/templates/auto-upgrades.j2
+++ b/templates/auto-upgrades.j2
@@ -1,6 +1,6 @@
 // {{ ansible_managed }}
 
-APT::Periodic::Unattended-Upgrade "1";
+APT::Periodic::Unattended-Upgrade "{{unattended_interval}}";
 
 {% if unattended_update_package_list is defined %}
 APT::Periodic::Update-Package-Lists "{{unattended_update_package_list}}";


### PR DESCRIPTION
For some systems, running every day by default is good, but it can be noisy too, so allow turning it down.