### PR TITLE
Suppress blank template lines

### DIFF
--- a/templates/auto-upgrades.j2
+++ b/templates/auto-upgrades.j2
@@ -1,27 +1,27 @@
 // {{ ansible_managed }}
 
 APT::Periodic::Unattended-Upgrade "1";
-
 {% if unattended_update_package_list is defined %}
+
 APT::Periodic::Update-Package-Lists "{{unattended_update_package_list}}";
 {% endif %}
-
 {% if unattended_download_upgradeable is defined %}
+
 APT::Periodic::Download-Upgradeable-Packages "{{unattended_download_upgradeable}}";
 {% endif %}
-
 {% if unattended_autoclean_interval is defined %}
+
 APT::Periodic::AutocleanInterval "{{unattended_autoclean_interval}}";
 {% endif %}
-
 {% if unattended_clean_interval is defined %}
+
 APT::Periodic::CleanInterval "{{unattended_clean_interval}}";
 {% endif %}
-
 {% if unattended_verbose is defined %}
+
 APT::Periodic::Verbose "{{unattended_verbose}}";
 {% endif %}
-
 {% if unattended_random_sleep is defined %}
+
 APT::Periodic::RandomSleep "{{unattended_random_sleep}}";
 {% endif %}

--- a/templates/unattended-upgrades.j2
+++ b/templates/unattended-upgrades.j2
@@ -20,8 +20,8 @@ Unattended-Upgrade::Package-Blacklist {
       "{{package}}";
 {% endfor %}
 };
-
 {% if not unattended_autofix_interrupted_dpkg %}
+
 // This option allows you to control if on a unclean dpkg exit
 // unattended-upgrades will automatically run
 //   dpkg --force-confold --configure -a
@@ -34,53 +34,53 @@ Unattended-Upgrade::AutoFixInterruptedDpkg "false";
 // a bit slower but it has the benefit that shutdown while a upgrade
 // is running is possible (with a small delay)
 Unattended-Upgrade::MinimalSteps "{{ unattended_minimal_steps | lower }}";
-
 {% if unattended_install_on_shutdown %}
+
 // Install all unattended-upgrades when the machine is shuting down
 // instead of doing it in the background while the machine is running
 // This will (obviously) make shutdown slower
 Unattended-Upgrade::InstallOnShutdown "true";
 {% endif %}
-
 {% if unattended_mail %}
+
 // Send email to this address for problems or packages upgrades
 // If empty or unset then no email is sent, make sure that you
 // have a working mail setup on your system. A package that provides
 // 'mailx' must be installed.
 Unattended-Upgrade::Mail "{{unattended_mail}}";
 {% endif %}
-
 {% if unattended_mail_only_on_error %}
+
 // Set this value to "true" to get emails only on errors. Default
 // is to always send a mail if Unattended-Upgrade::Mail is set
 Unattended-Upgrade::MailOnlyOnError "true";
 {% endif %}
-
 {% if unattended_remove_unused_dependencies %}
+
 // Do automatic removal of all unused dependencies after the upgrade
 // (equivalent to apt-get autoremove)
 Unattended-Upgrade::Remove-Unused-Dependencies "true";
 {% endif %}
-
 {% if not unattended_remove_new_unused_dependencies %}
+
 // Do automatic removal of new unused dependencies after the upgrade
 Unattended-Upgrade::Remove-New-Unused-Dependencies "false";
 {% endif %}
-
 {% if unattended_automatic_reboot %}
+
 // Automatically reboot *WITHOUT CONFIRMATION* if a
 // the file /var/run/reboot-required is found after the upgrade
 Unattended-Upgrade::Automatic-Reboot "true";
 {% endif %}
-
 {% if unattended_automatic_reboot_time %}
+
 // If automatic reboot is enabled and needed, reboot at the specific
 // time instead of immediately
 //  Default: "now"
 Unattended-Upgrade::Automatic-Reboot-Time "{{ unattended_automatic_reboot_time }}";
 {% endif %}
-
 {% if unattended_update_days is defined %}
+
 // Set the days of the week that updates should be applied. The days can be specified
 // as localized abbreviated or full names. Or as integers where "0" is Sunday, "1" is
 // Monday etc.
@@ -88,26 +88,27 @@ Unattended-Upgrade::Automatic-Reboot-Time "{{ unattended_automatic_reboot_time }
 // {"Mon";"Fri"};
 Unattended-Upgrade::Update-Days {{ unattended_update_days }};
 {% endif %}
-
 {% if unattended_ignore_apps_require_restart %}
+
 // Do upgrade application even if it requires restart after upgrade
 // I.e. "XB-Upgrade-Requires: app-restart" is set in the debian/control file
 Unattended-Upgrade::IgnoreAppsRequireRestart "true";
 {% endif %}
-
 {% if unattended_syslog_enable %}
+
 // Write events to syslog, which is useful in environments where syslog
 // messages are sent to a central store.
 Unattended-Upgrade::SyslogEnable "{{ unattended_syslog_enable }}";
 {% if unattended_syslog_facility is defined %}
+
 // Write events to the specified syslog facility, or the daemon facility
 // if not specified. Requires the Unattended-Upgrade::SyslogEnable option
 // to be set to true.
 Unattended-Upgrade::SyslogFacility "{{ unattended_syslog_facility }}";
 {% endif %}
 {% endif %}
-
 {% if unattended_dpkg_options %}
+
 // Append options for governing dpkg behavior, e.g. --force-confdef.
 Dpkg::Options {
 {% for dpkg_option in unattended_dpkg_options %}
@@ -115,8 +116,8 @@ Dpkg::Options {
 {% endfor %}
 };
 {% endif %}
-
 {% if unattended_dl_limit is defined %}
+
 // Use apt bandwidth limit feature, this example limits the download
 // speed to 70kb/sec
 Acquire::http::Dl-Limit "{{ unattended_dl_limit }}";


### PR DESCRIPTION
My /etc/apt/apt.conf.d/50unattended-upgrades are coming out with an extra 5 trailing lines that are distracting.

Maybe this is better handled with https://jinja.palletsprojects.com/en/master/templates/#whitespace-control but I don't understand how to use that.