### PR TITLE
Remove `update-notifier-common`.

### DIFF
--- a/tasks/reboot.yml
+++ b/tasks/reboot.yml
@@ -1,9 +1,0 @@
----
-# Ignored, since newer distros don't need this package
-# https://github.com/jnv/ansible-role-unattended-upgrades/issues/6
-- name: install update-notifier-common
-  apt:
-    pkg: update-notifier-common
-    state: present
-  failed_when: false
-

--- a/tasks/unattended-upgrades.yml
+++ b/tasks/unattended-upgrades.yml
@@ -21,10 +21,6 @@
     cache_valid_time: "{{ unattended_cache_valid_time }}"
     update_cache: yes
 
-- name: install reboot dependencies
-  include: reboot.yml
-  when: unattended_automatic_reboot|bool
-
 - name: create APT auto-upgrades configuration
   template:
     src: auto-upgrades.j2


### PR DESCRIPTION
It's been 5 years so this workaround is no longer need. Fixes #47 (and lets me use `unattended-upgrades` *in lieu of* bothering all of my users with update notifications every time they log in).