### PR TITLE
Fix issue where when using multiline comments

### DIFF
--- a/templates/auto-upgrades.j2
+++ b/templates/auto-upgrades.j2
@@ -1,4 +1,4 @@
-// {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 APT::Periodic::Unattended-Upgrade "1";
 


### PR DESCRIPTION
When you use multiline comments only the first line would be commented. This PR fixes this behaviour