### PR TITLE
Support Debian bullseye

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,6 +16,8 @@ galaxy_info:
     versions:
      - wheezy
      - jessie
+     - buster
+     - bullseye
   #
   # Below are all categories currently available. Just as with
   # the platforms above, uncomment those that apply to your role.

--- a/tasks/unattended-upgrades.yml
+++ b/tasks/unattended-upgrades.yml
@@ -6,6 +6,10 @@
   include_vars: "{{ ansible_distribution }}-{{ ansible_distribution_release }}.yml"
   when: (ansible_distribution == "Debian") and (ansible_distribution_release == "wheezy")
 
+- name: add Debian Bullseye workaround
+  include_vars: "{{ ansible_distribution }}-{{ ansible_distribution_release }}.yml"
+  when: (ansible_distribution == "Debian") and (ansible_distribution_release == "bullseye")
+
 - name: install powermgmt-base
   apt:
     pkg:

--- a/vars/Debian-bullseye.yml
+++ b/vars/Debian-bullseye.yml
@@ -1,0 +1,4 @@
+---
+__unattended_origins_patterns:
+  - 'origin=Debian,codename=${distro_codename},label=Debian-Security'
+  - 'origin=Debian,codename=${distro_codename}-security,label=Debian-Security'

--- a/vars/Debian-bullseye.yml
+++ b/vars/Debian-bullseye.yml
@@ -1,4 +1,9 @@
 ---
+# From https://metadata.ftp-master.debian.org/changelogs//main/u/unattended-upgrades/unattended-upgrades_2.8_changelog
+#  Allow both ${distro_codename} or ${distro_codename}-security on Debian
+#  as security update codenames. The latter will be used starting with
+#  Bullseye, but to help backporting and testing the configuration file keeps
+#  working on Buster and older releases. (Closes: #933138)
 __unattended_origins_patterns:
   - 'origin=Debian,codename=${distro_codename},label=Debian-Security'
   - 'origin=Debian,codename=${distro_codename}-security,label=Debian-Security'


### PR DESCRIPTION
Starting with Debian 11 (bullseye) there are _two_  security code names. See the entry for 1.14 in the [changelog](https://metadata.ftp-master.debian.org/changelogs//main/u/unattended-upgrades/unattended-upgrades_2.8_changelog).
I've copied the wheezy 'workaround' task, but not sure that wording is correct now as it's not really a workaround?