### PR TITLE
chore(includes): fixed deprecated include with include_tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,2 @@
- - include: unattended-upgrades.yml
+ - include_tasks: unattended-upgrades.yml
    tags: unattended

--- a/tasks/unattended-upgrades.yml
+++ b/tasks/unattended-upgrades.yml
@@ -14,7 +14,7 @@
     update_cache: yes
 
 - name: install reboot dependencies
-  include: reboot.yml
+  include_tasks: reboot.yml
   when: unattended_automatic_reboot|bool
 
 - name: create APT auto-upgrades configuration


### PR DESCRIPTION
Hi, I switched `include` with `include_tasks`, because `include` is deprecated.

```bash
[DEPRECATION WARNING]: "include" is deprecated, use include_tasks/import_tasks/import_playbook instead. This feature will be removed in version 2.16. Deprecation warnings can be
disabled by setting deprecation_warnings=False in ansible.cfg.
```
---

Thanks for your ansible role :) 